### PR TITLE
Utilização da imagem docker e versão oficial do codenarc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
-FROM asaasdev/codenarc:2.0.0
+FROM codenarc/codenarc:2.2.0-groovy3.0.8
+
+RUN DEBIAN_FRONTEND=noninteractive \
+apt-get update && \
+apt-get install -y wget git && \
+apt-get clean && rm -rf /var/lib/apt/lists/* 
 
 ENV REVIEWDOG_VERSION=v0.13.0
 
-USER root
-
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}
-
-USER groovy
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM codenarc/codenarc:2.2.0-groovy3.0.8
 
 RUN DEBIAN_FRONTEND=noninteractive \
 apt-get update && \
-apt-get install -y wget git && \
+apt-get install --no-install-recommends -y wget git && \
 apt-get clean && rm -rf /var/lib/apt/lists/* 
 
 ENV REVIEWDOG_VERSION=v0.13.0

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,9 @@ inputs:
     description: 'Additional reviewdog flags'
     default: ''
   ### Parameters for codenarc ###
+  report:
+    description: '-report parameter of codenarc CLI.'
+    default: 'compact:stdout'  
   rulesetfiles:
     description: '-rulesetfiles parameter of codenarc CLI. (This can be a single file path, or multiple paths separated by commas.)'
     default: 'rulesets/basic.xml'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ fi
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
-codenarc -report=inlineConsole:stdout -rulesetfiles="${INPUT_RULESETFILES}" \
+java -jar /lib/codenarc-all.jar -report="${INPUT_REPORT:-compact:stdout}" -rulesetfiles="${INPUT_RULESETFILES}" \
   | reviewdog -efm="%f:%l:%m" -efm="%f:%r:%m" \
       -name="codenarc" \
       -reporter="${INPUT_REPORTER:-github-pr-check}" \


### PR DESCRIPTION
Alterado para utilizar imagem docker oficial do [codenarc](https://github.com/CodeNarc/CodeNarc/tree/master/docker) e versão 2.2.0-groovy3.0.8, mantendo a utilização do reviewdog.