### PR TITLE
Removendo ShellCheck pois não existe mais .sh no repositorio

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -5,23 +5,6 @@ on:
       - master
   pull_request:
 jobs:
-  shellcheck:
-    name: runner / shellcheck
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: haya14busa/action-cond@v1
-        id: reporter
-        with:
-          cond: ${{ github.event_name == 'pull_request' }}
-          if_true: "github-pr-review"
-          if_false: "github-check"
-      - uses: reviewdog/action-shellcheck@v1.9
-        with:
-          github_token: ${{ secrets.github_token }}
-          reporter: ${{ steps.reporter.outputs.value }}
-          level: warning
-
   misspell:
     name: runner / misspell
     runs-on: ubuntu-latest


### PR DESCRIPTION
Removendo Actions ShellCheck pois não possuimos mais o .sh no repositório e estava quebrando a verificação. https://github.com/asaasdev/codenarc-action/actions/runs/1305078416

Como essa alteração não afeta a action, não mudará a versão no marketplace.